### PR TITLE
Add scrollTo effect on pathname change in Lenis Context

### DIFF
--- a/src/components/common/lenis-provider/lenis-provider.tsx
+++ b/src/components/common/lenis-provider/lenis-provider.tsx
@@ -1,12 +1,24 @@
 "use client";
 
-import ReactLenis from "lenis/react";
-import type { ReactNode } from "react";
+import ReactLenis, { useLenis } from "lenis/react";
+import { type ReactNode, useEffect } from "react";
+
+import { usePathname } from "next/navigation";
+
+import Lenis from "lenis";
 
 type LenisProviderProps = Readonly<{
   children: ReactNode;
 }>;
 
 export default function LenisProvider({ children }: LenisProviderProps): ReactNode {
+  const pathname: string = usePathname();
+  const lenis: Lenis | undefined = useLenis();
+
+  useEffect(() => {
+    if (!lenis) return;
+    lenis.scrollTo(0, { immediate: true, force: true });
+  }, [pathname, lenis]);
+
   return <ReactLenis root>{children}</ReactLenis>;
 }


### PR DESCRIPTION
This pull request includes changes to the `LenisProvider` component to enhance its functionality by adding scroll position management based on the current pathname.

The most important changes include:

* Added `useLenis` and `usePathname` hooks to manage Lenis scrolling and react to pathname changes.
* Implemented a `useEffect` hook to reset the scroll position to the top whenever the pathname changes.