### PR TITLE
Fix spelling of 'icons' in middleware matcher configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,16 @@
+# DATABASE INFORMATION
+DATABASE_URL="call @pierregueroult to get the database URL"
+
+# AUTHENTICATION INFORMATION
+AUTH_SECRET="generate with 'npx auth secret'"
+AUTH_TRUST_HOST="true"
+
+# DEPLOYMENT INFORMATION
+NEXT_PUBLIC_AUTH_URL="http://auth.localhost:3000"
+NEXT_PUBLIC_ROOT_URL="http://localhost:3000"
+NEXT_PUBLIC_DOWNLOAD_URL="http://download.localhost:3000"
+NEXT_PUBLIC_WIKI_URL="http://wiki.localhost:3000"
+NEXT_PUBLIC_STUDIO_URL="http://weare.localhost:3000"
+
+# WEBSITE PARAMETERS
+NEXT_PUBLIC_WEBSITE_DEBUG="true"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,7 +7,7 @@ import { buildSubdomainUrl, getSubdomains, isValidSubdomain } from "@/services/s
 import { Subdomain } from "@/types/subdomain";
 
 export const config: MiddlewareConfig = {
-  matcher: ["/((?!api/|_next/|images/|textures/|sources/|icones/|_static/|_vercel|[\\w-]+\\.\\w+).*)"],
+  matcher: ["/((?!api/|_next/|images/|textures/|sources/|icons/|_static/|_vercel|[\\w-]+\\.\\w+).*)"],
 };
 
 async function subdomains(req: NextRequest): Promise<NextResponse> {


### PR DESCRIPTION
Correct the spelling of 'icones' to 'icons' in the matcher configuration for middleware.